### PR TITLE
Allow codeblocks to be ignored

### DIFF
--- a/src/CodeBlockExtractor.ts
+++ b/src/CodeBlockExtractor.ts
@@ -1,7 +1,7 @@
 import * as fsExtra from 'fs-extra'
 
 export class CodeBlockExtractor {
-  static readonly TYPESCRIPT_CODE_PATTERN = /(?:```(?:(?:typescript)|(?:ts))\n)((?:\n|.)*?)(?:(?=```))/gi
+  static readonly TYPESCRIPT_CODE_PATTERN = /(?<!<!--\s*docs-verifier-ignore\s*-->[\r\n]*)(?:```(?:(?:typescript)|(?:ts))\n)((?:\n|.)*?)(?:(?=```))/gi
 
   /* istanbul ignore next */
   private constructor () {}

--- a/src/CodeBlockExtractor.ts
+++ b/src/CodeBlockExtractor.ts
@@ -1,7 +1,7 @@
 import * as fsExtra from 'fs-extra'
 
 export class CodeBlockExtractor {
-  static readonly TYPESCRIPT_CODE_PATTERN = /(?<!<!--\s*docs-verifier-ignore\s*-->[\r\n]*)(?:```(?:(?:typescript)|(?:ts))\n)((?:\n|.)*?)(?:(?=```))/gi
+  static readonly TYPESCRIPT_CODE_PATTERN = /(?<!<!---\s*docs-verifier-ignore\s*-->[\r\n]*)(?:```(?:(?:typescript)|(?:ts))\n)((?:\n|.)*?)(?:(?=```))/gi
 
   /* istanbul ignore next */
   private constructor () {}

--- a/test/TypeScriptDocsVerifierSpec.ts
+++ b/test/TypeScriptDocsVerifierSpec.ts
@@ -157,9 +157,9 @@ ${wrapSnippet(strings[3], 'bash')}
     )
 
     verify.it(
-      'does not return result if a valid typescript block marked "ts" is supplied if it is preceded by <!-- docs-verifier-ignore --> ',
+      'does not return result if a valid typescript block marked "ts" is supplied if it is preceded by <!--- docs-verifier-ignore --> ',
       genSnippet, Gen.string, async (snippet, fileName) => {
-        const ignoreString = `<!-- docs-verifier-ignore -->`
+        const ignoreString = `<!--- docs-verifier-ignore -->`
         const typeScriptMarkdown = `${ignoreString}${wrapSnippet(snippet, 'ts')}`
         await createProject({ markdownFiles: [{ name: fileName, contents: typeScriptMarkdown }] })
         return TypeScriptDocsVerifier.compileSnippets(fileName)

--- a/test/TypeScriptDocsVerifierSpec.ts
+++ b/test/TypeScriptDocsVerifierSpec.ts
@@ -157,6 +157,17 @@ ${wrapSnippet(strings[3], 'bash')}
     )
 
     verify.it(
+      'does not return result if a valid typescript block marked "ts" is supplied if it is preceded by <!-- docs-verifier-ignore --> ',
+      genSnippet, Gen.string, async (snippet, fileName) => {
+        const ignoreString = `<!-- docs-verifier-ignore -->`
+        const typeScriptMarkdown = `${ignoreString}${wrapSnippet(snippet, 'ts')}`
+        await createProject({ markdownFiles: [{ name: fileName, contents: typeScriptMarkdown }] })
+        return TypeScriptDocsVerifier.compileSnippets(fileName)
+          .should.eventually.eql([])
+      }
+    )
+
+    verify.it(
       'compiles snippets from multiple files',
       Gen.distinct(genSnippet, 3), Gen.distinct(Gen.string, 3), async (snippets, fileNames) => {
         const markdownFiles = snippets.map((snippet, index) => {

--- a/test/TypeScriptDocsVerifierSpec.ts
+++ b/test/TypeScriptDocsVerifierSpec.ts
@@ -157,7 +157,7 @@ ${wrapSnippet(strings[3], 'bash')}
     )
 
     verify.it(
-      'does not return result if a valid typescript block marked "ts" is supplied if it is preceded by <!--- docs-verifier-ignore --> ',
+      'does not return result if a valid typescript block marked "ts" is supplied and it is preceded by <!--- docs-verifier-ignore --> ',
       genSnippet, Gen.string, async (snippet, fileName) => {
         const ignoreString = `<!--- docs-verifier-ignore -->`
         const typeScriptMarkdown = `${ignoreString}${wrapSnippet(snippet, 'ts')}`


### PR DESCRIPTION
Hi @paulbrimicombe! I hope you are well 🙃 

I'm trying to use this package for an internal documentation package at work. Unfortunately, it's blowing up because some of the snippets are ambient declarations, so I'm getting the following error:

```An ambient module declaration is only allowed at the top level in a file.```

presumably because you inject the snippets into a wrapper of some kind in order to compile them

It would be nice to fix that specific problem, but I imagine that would be harder. This PR fixes my immediate problem by adjusting the codeblock extractor regex so that blocks can be ignored by preceding them with `<!--- docs-verifier-ignore -->`, so that I can just ignore these blocks.

Note, this is probably also useful for people who want to deliberately show examples of invalid TypeScript.