### PR TITLE
Support references to project dependencies during snippet compilation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Link project `node_modules` to snippet compilation directory so you can import from the current project's dependencies in snippets
 
 ## [2.1.0]
 ### Changed

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 import * as os from 'os'
 import * as path from 'path'
+import { PackageInfo } from './src/PackageInfo'
 import { SnippetCompiler, SnippetCompilationResult } from './src/SnippetCompiler'
 
 export { SnippetCompilationResult } from './src/SnippetCompiler'
@@ -16,7 +17,8 @@ const wrapIfString = (arrayOrString: string[] | string) => {
 
 export async function compileSnippets (markdownFileOrFiles: string | string[] = DEFAULT_FILES): Promise<SnippetCompilationResult[]> {
   const compiledDocsFolder = path.join(os.tmpdir(), 'compiled-docs')
-  const compiler = new SnippetCompiler(compiledDocsFolder)
+  const packageDefinition = await PackageInfo.read()
+  const compiler = new SnippetCompiler(compiledDocsFolder, packageDefinition)
   const fileArray = wrapIfString(markdownFileOrFiles)
   const results = await compiler.compileSnippets(fileArray)
   return results

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "eslint-plugin-import": "^2.24.2",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.1.0",
-    "mocha": "^9.1.2",
+    "mocha": "^9.2.1",
     "mocha-jenkins-reporter": "^0.4.7",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",

--- a/src/LocalImportSubstituter.ts
+++ b/src/LocalImportSubstituter.ts
@@ -8,7 +8,7 @@ export class LocalImportSubstituter {
   constructor (packageDefinition: PackageDefinition) {
     this.packageName = packageDefinition.name
     const mainImport = packageDefinition.main.replace(/\.(ts|js)$/, '')
-    this.pathToPackageMain = path.join(process.cwd(), mainImport)
+    this.pathToPackageMain = path.join(packageDefinition.packageRoot, mainImport)
   }
 
   substituteLocalPackageImports (code: string) {

--- a/src/PackageInfo.ts
+++ b/src/PackageInfo.ts
@@ -4,6 +4,21 @@ import * as fsExtra from 'fs-extra'
 export type PackageDefinition = {
   readonly name: string
   readonly main: string
+  readonly packageRoot: string
+}
+
+const searchParentsForPackage = async (currentPath: string): Promise<string> => {
+  try {
+    await fsExtra.readFile(path.join(currentPath, 'package.json'))
+    return currentPath
+  } catch {
+    const parentPath = path.dirname(currentPath)
+
+    if (parentPath === currentPath) {
+      throw new Error('Failed to find package.json — are you running this inside a NodeJS project?')
+    }
+    return await searchParentsForPackage(parentPath)
+  }
 }
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
@@ -12,8 +27,15 @@ export class PackageInfo {
   private constructor () {}
 
   static async read (): Promise<PackageDefinition> {
-    const packageJsonPath = path.join(process.cwd(), 'package.json')
+    const packageRoot = await searchParentsForPackage(process.cwd())
+    const packageJsonPath = path.join(packageRoot, 'package.json')
     const contents = await fsExtra.readFile(packageJsonPath, 'utf-8')
-    return JSON.parse(contents)
+    const packageInfo = JSON.parse(contents)
+
+    return {
+      name: packageInfo.name,
+      main: packageInfo.main,
+      packageRoot
+    }
   }
 }


### PR DESCRIPTION
# Problem

* See https://github.com/bbc/typescript-docs-verifier/issues/11
* Sometimes a snippet might require import of another package. These would typically be in the current project's dependencies.
* This _used_ to work because previously the snippets were compiled to a subdirectory of the current project

# Solution

* Symlink the `node_modules` folder from the current project to the directory where the snippets are compiled before compilation.

## Notes

* Also fixed a bug where `compile-typescript-docs` had to be run in the root of the project.
* Now it can be run from a subdirectory (file args are relative to the current working directory, including the default of `README.md`.