### PR TITLE
Support scoped packages

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Link project `node_modules` to snippet compilation directory so you can import from the current project's dependencies in snippets
 
+### Added
+- Support for importing sub-paths within packages
+- Support for scoped package names
+
 ## [2.1.0]
 ### Changed
 - No longer wrap TypeScript code blocks in functions before compilation

--- a/src/LocalImportSubstituter.ts
+++ b/src/LocalImportSubstituter.ts
@@ -12,11 +12,13 @@ export class LocalImportSubstituter {
   }
 
   substituteLocalPackageImports (code: string) {
-    const projectImportRegex = new RegExp(`('${this.packageName}'|"${this.packageName}")`, 'g')
+    const escapedPackageName = this.packageName.replace(/\\/g, '\\/')
+    const projectImportRegex = new RegExp(`(?:'|")(${escapedPackageName})(/[^'"]+)?(?:'|"|)`, 'g')
     const codeLines = code.split('\n')
     const localisedLines = codeLines.map((line) => {
-      if (line.trim().startsWith('import ')) {
-        return line.replace(projectImportRegex, `'${this.pathToPackageMain}'`)
+      if (line.trim().startsWith('import ') && line.match(projectImportRegex)) {
+        const { 2: subPath } = line.match(projectImportRegex) ?? []
+        return line.replace(this.packageName, `${this.pathToPackageMain}${subPath ?? ''}`)
       } else {
         return line
       }


### PR DESCRIPTION
# Problem

- Scoped packages (with an `@` prefix aren't supported)
- Imports within packages aren't supported (e.g. `@scope/my-package/some/inner/path`)
- The script only works if you run it in the root of the project

# Solution

- Alter regex to support scoped packages and sub-paths
- Walk up the directory tree to find the nearest package.json

## Notes

- Also upgraded `mocha` to fix an audit failure