### PR TITLE
Path imports within packages should be relative to the root of the package

### DIFF
--- a/src/LocalImportSubstituter.ts
+++ b/src/LocalImportSubstituter.ts
@@ -3,10 +3,12 @@ import { PackageDefinition } from './PackageInfo'
 
 export class LocalImportSubstituter {
   private readonly packageName: string
+  private readonly packageRoot: string
   private readonly pathToPackageMain: string
 
   constructor (packageDefinition: PackageDefinition) {
     this.packageName = packageDefinition.name
+    this.packageRoot = packageDefinition.packageRoot
     const mainImport = packageDefinition.main.replace(/\.(ts|js)$/, '')
     this.pathToPackageMain = path.join(packageDefinition.packageRoot, mainImport)
   }
@@ -17,8 +19,12 @@ export class LocalImportSubstituter {
     const codeLines = code.split('\n')
     const localisedLines = codeLines.map((line) => {
       if (line.trim().startsWith('import ') && line.match(projectImportRegex)) {
-        const { 2: subPath } = line.match(projectImportRegex) ?? []
-        return line.replace(this.packageName, `${this.pathToPackageMain}${subPath ?? ''}`)
+        const { 2: subPath } = projectImportRegex.exec(line) ?? []
+
+        if (subPath) {
+          return line.replace(this.packageName, this.packageRoot)
+        }
+        return line.replace(this.packageName, `${this.pathToPackageMain}`)
       } else {
         return line
       }

--- a/test/TypeScriptDocsVerifierSpec.ts
+++ b/test/TypeScriptDocsVerifierSpec.ts
@@ -13,7 +13,7 @@ const defaultPackageJson = {
   main: `${Gen.string()}.ts`
 }
 const defaultMainFile = {
-  name: 'main-default.ts',
+  name: defaultPackageJson.main,
   contents: FsExtra.readFileSync(path.join(fixturePath, 'main-default.ts')).toString()
 }
 
@@ -99,7 +99,8 @@ describe('TypeScriptDocsVerifier', () => {
     })
 
     afterEach(async () => {
-      await FsExtra.remove(workingDirectory)
+      // await FsExtra.remove(workingDirectory)
+      console.log(workingDirectory)
     })
 
     verify.it('returns an empty array if no code snippets are present', async () => {
@@ -353,13 +354,13 @@ Gen.string()
 
     verify.it(
       'localises imports of files within the current package', async () => {
+        const sourceFolder = Gen.word()
         const snippet = `
-          import { MyClass } from '${defaultPackageJson.name}/other'
+          import { MyClass } from '${defaultPackageJson.name}/${sourceFolder}/other'
           const instance = new MyClass()
           instance.doStuff()`
-        const mainLocation = 'src'
         const mainFile = {
-          name: path.join(mainLocation, 'index.ts'),
+          name: defaultMainFile.name,
           contents: `
             export class MainClass {
               doStuff (): void {
@@ -368,7 +369,7 @@ Gen.string()
             }`
         }
         const otherFile = {
-          name: path.join(mainLocation, 'other.ts'),
+          name: path.join(sourceFolder, 'other.ts'),
           contents: `
             export class MyClass {
               doStuff (): void {
@@ -380,10 +381,6 @@ Gen.string()
         await createProject({
           markdownFiles: [{ name: 'README.md', contents: typeScriptMarkdown }],
           mainFile,
-          packageJson: {
-            main: mainLocation,
-            name: defaultPackageJson.name
-          },
           otherFiles: [otherFile]
         })
         return await TypeScriptDocsVerifier.compileSnippets()
@@ -433,13 +430,13 @@ Gen.string()
 
     verify.it(
       'localises imports of files within the current package when the package is scoped', async () => {
+        const sourceFolder = Gen.word()
         const snippet = `
-          import { MyClass } from '@bbc/${defaultPackageJson.name}/other'
+          import { MyClass } from '@bbc/${defaultPackageJson.name}/${sourceFolder}/other'
           const instance = new MyClass()
           instance.doStuff()`
-        const mainLocation = 'src'
         const mainFile = {
-          name: path.join(mainLocation, 'index.ts'),
+          name: defaultMainFile.name,
           contents: `
             export class MainClass {
               doStuff (): void {
@@ -448,7 +445,7 @@ Gen.string()
             }`
         }
         const otherFile = {
-          name: path.join(mainLocation, 'other.ts'),
+          name: path.join(sourceFolder, 'other.ts'),
           contents: `
             export class MyClass {
               doStuff (): void {
@@ -461,7 +458,7 @@ Gen.string()
           markdownFiles: [{ name: 'README.md', contents: typeScriptMarkdown }],
           mainFile,
           packageJson: {
-            main: mainLocation,
+            main: defaultPackageJson.main,
             name: `@bbc/${defaultPackageJson.name}`
           },
           otherFiles: [otherFile]


### PR DESCRIPTION
Partial fix for #11 — imports of files within packages are relative to the root of the package, not relative to the `main` script.