### PR TITLE
Relative path imports with overlapping names

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript",
     "verify"
   ],
-  "version": "2.2.0-alpha2",
+  "version": "2.1.0",
   "main": "dist/index.js",
   "@types": "dist/index.d.ts",
   "bin": "./dist/bin/compile-typescript-docs.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript",
     "verify"
   ],
-  "version": "2.1.0",
+  "version": "2.2.0-alpha2",
   "main": "dist/index.js",
   "@types": "dist/index.d.ts",
   "bin": "./dist/bin/compile-typescript-docs.js",

--- a/src/LocalImportSubstituter.ts
+++ b/src/LocalImportSubstituter.ts
@@ -15,19 +15,28 @@ export class LocalImportSubstituter {
 
   substituteLocalPackageImports (code: string) {
     const escapedPackageName = this.packageName.replace(/\\/g, '\\/')
-    const projectImportRegex = new RegExp(`(?:'|")(${escapedPackageName})(/[^'"]+)?(?:'|"|)`, 'g')
+    const projectImportRegex = new RegExp(`('|")(?:${escapedPackageName})(/[^'"]+)?('|"|)`)
     const codeLines = code.split('\n')
-    const localisedLines = codeLines.map((line) => {
-      if (line.trim().startsWith('import ') && line.match(projectImportRegex)) {
-        const { 2: subPath } = projectImportRegex.exec(line) ?? []
 
-        if (subPath) {
-          return line.replace(this.packageName, this.packageRoot)
-        }
-        return line.replace(this.packageName, `${this.pathToPackageMain}`)
-      } else {
+    const localisedLines = codeLines.map((line) => {
+      if (!line.trim().startsWith('import ')) {
         return line
       }
+
+      const match = projectImportRegex.exec(line)
+      if (!match) {
+        return line
+      }
+
+      const { 1: openQuote, 2: subPath, 3: closeQuote, index } = match
+
+      const prefix = line.substring(0, index)
+
+      if (subPath) {
+        return `${prefix}${openQuote}${this.packageRoot}${subPath}${closeQuote}`
+      }
+
+      return `${prefix}${openQuote}${this.pathToPackageMain}${closeQuote}`
     })
     return localisedLines.join('\n')
   }

--- a/test/LocalImportSubstituterSpec.ts
+++ b/test/LocalImportSubstituterSpec.ts
@@ -1,0 +1,84 @@
+/* eslint-disable @typescript-eslint/quotes */
+import { expect } from 'chai'
+import { LocalImportSubstituter } from '../src/LocalImportSubstituter'
+
+const scenarios = [{
+  importLine: `import something from 'awesome'`,
+  expected: `import something from '/path/to/package/index'`,
+  name: 'single quotes'
+}, {
+  importLine: `import something from 'awesome';`,
+  expected: `import something from '/path/to/package/index'`,
+  name: 'a trailing semicolon'
+}, {
+  importLine: `import something from "awesome"`,
+  expected: `import something from "/path/to/package/index"`,
+  name: 'double quotes'
+}, {
+  importLine: `import something from "awesome"      `,
+  expected: `import something from "/path/to/package/index"`,
+  name: 'trailing whitespace'
+}, {
+  importLine: `import something from '@my-scope/awesome'`,
+  expected: `import something from '/path/to/package/index'`,
+  name: 'a scoped package name',
+  packageName: '@my-scope/awesome'
+}, {
+  importLine: `import something from 'awesome/some/inner/path'`,
+  expected: `import something from '/path/to/package/some/inner/path'`,
+  name: 'imports of paths within a package'
+}, {
+  importLine: `import something from '@my-scope/awesome/some/inner/path'`,
+  expected: `import something from '/path/to/package/some/inner/path'`,
+  name: 'imports of paths within a scoped package',
+  packageName: '@my-scope/awesome'
+}, {
+  importLine: `import lib from 'lib/lib/lib'`,
+  expected: `import lib from '/path/to/package/lib/lib'`,
+  name: 'overlapping library and path names',
+  packageName: 'lib'
+}, {
+  importLine: `import lib from '@lib/lib/lib/lib'`,
+  expected: `import lib from '/path/to/package/lib/lib'`,
+  name: 'overlapping library, path and scope names',
+  packageName: '@lib/lib'
+}]
+
+describe('LocalImportSubstituter', () => {
+  it('does not change imports for different packages', () => {
+    const substituter = new LocalImportSubstituter({
+      name: 'my-package',
+      main: 'index.ts',
+      packageRoot: '/path/to/package'
+    })
+
+    const code = `import * as other from "package"
+
+console.log('Should not be mutated')`
+    const result = substituter.substituteLocalPackageImports(code)
+
+    expect(result).to.eql(code)
+  })
+
+  scenarios.forEach(({ importLine, expected, name, packageName = 'awesome' }) => {
+    it(`localises imports with ${name}`, () => {
+      const substituter = new LocalImportSubstituter({
+        name: packageName,
+        main: 'index.ts',
+        packageRoot: '/path/to/package'
+      })
+
+      const code = `
+${importLine}
+
+console.log('Something happened')
+      `
+
+      const localised = substituter.substituteLocalPackageImports(code)
+
+      expect(localised).satisfies((actual: string) => {
+        return actual.trim().startsWith(expected)
+      }, `${localised} should start with ${expected}`)
+    })
+  })
+})


### PR DESCRIPTION
# Problem

- With the current implementation, the wrong part of the import statement can be localised if the library name is somewhere else in the line (e.g. `import jest from 'jest'`).

# Solution

- Make sure we only substitute the file paths in the correct part of the import statement.