### PR TITLE
Allow code blocks to be ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ These code blocks are extracted and any imports from the current project are rep
 
 Each code snippet is compiled (but not run) and any compilation errors are reported. Code snippets must compile independently from any other code snippets in the file.
 
+### Ignoring code blocks
+
+Individual code blocks can be ignored by preceding them with a `<!-- ts-docs-verifier:ignore -->` comment:
+
+````Markdown
+<!-- ts-docs-verifier:ignore -->
+```typescript
+// This block won't be compiled by typescript-docs-verifier
+```
+````
+
 ## Script usage
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mocha-jenkins-reporter": "^0.4.7",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",
-    "typescript": "^4.3.5",
+    "typescript": "4.3.5",
     "verify-it": "^2.0.1"
   },
   "dependencies": {
@@ -73,7 +73,7 @@
     "fs-extra": "^10.0.0",
     "ora": "^5.4.1",
     "strip-ansi": "^6.0.1",
-    "ts-node": "^10.0.0",
+    "ts-node": "10.4.0",
     "tsconfig": "^7.0.0",
     "yargs": "^17.2.1"
   },

--- a/src/CodeBlockExtractor.ts
+++ b/src/CodeBlockExtractor.ts
@@ -2,7 +2,7 @@ import * as fsExtra from 'fs-extra'
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class CodeBlockExtractor {
-  static readonly TYPESCRIPT_CODE_PATTERN = /(?:```(?:(?:typescript)|(?:ts))\n)((?:\n|.)*?)(?:(?=```))/gi
+  static readonly TYPESCRIPT_CODE_PATTERN = /(?<!(?:<!--\s*ts-docs-verifier:ignore\s*-->[\r\n]*))(?:```(?:(?:typescript)|(?:ts))\n)((?:\n|.)*?)(?:(?=```))/gi
 
   /* istanbul ignore next */
   private constructor () {}

--- a/test/TypeScriptDocsVerifierSpec.ts
+++ b/test/TypeScriptDocsVerifierSpec.ts
@@ -162,6 +162,17 @@ ${wrapSnippet(strings[3], 'bash')}
     )
 
     verify.it(
+      'ignores code blocks preceded by <!-- ts-docs-verifier:ignore --> ',
+      genSnippet, Gen.string, async (snippet, fileName) => {
+        const ignoreString = '<!-- ts-docs-verifier:ignore -->'
+        const typeScriptMarkdown = `${ignoreString}${wrapSnippet(snippet, 'ts')}`
+        await createProject({ markdownFiles: [{ name: fileName, contents: typeScriptMarkdown }] })
+        return await TypeScriptDocsVerifier.compileSnippets(fileName)
+          .should.eventually.eql([])
+      }
+    )
+
+    verify.it(
       'compiles snippets from multiple files',
       Gen.distinct(genSnippet, 6), Gen.distinct(Gen.string, 3), async (snippets, fileNames) => {
         const markdownFiles = fileNames.map((fileName, index) => {


### PR DESCRIPTION
# Problem

- Currently there is no way to skip compilation of single blocks in a file.
- This can cause problems for some clients since they have individual code blocks that can't be compiled for whatever reason.

# Solution

- Allow a comment to be added in front of code blocks that mean they are skipped by the docs verifier.

## Notes

- Also pinned the `ts-node` version to ensure that the line numbers can still be extracted from the diagnostic text.