### PR TITLE
Use latest ts-node and extract line numbers from diagnostics

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2]
+### Changed
+- Unpinned `ts-node` dependency to fix issues with the most recent TypeScript versions (required the extraction of the line numbers of compilation errors to be changed)
+
 ## [2.2.1]
 ### Added
 - Allow code blocks to be ignored by preceding them with a `<!-- ts-docs-verifier:ignore -->` comment

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mocha-jenkins-reporter": "^0.4.7",
     "npm-run-all": "^4.1.5",
     "nyc": "^15.0.0",
-    "typescript": "4.3.5",
+    "typescript": "^4.7.3",
     "verify-it": "^2.0.1"
   },
   "dependencies": {
@@ -73,7 +73,7 @@
     "fs-extra": "^10.0.0",
     "ora": "^5.4.1",
     "strip-ansi": "^6.0.1",
-    "ts-node": "10.4.0",
+    "ts-node": "^10.8.1",
     "tsconfig": "^7.0.0",
     "yargs": "^17.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript",
     "verify"
   ],
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "dist/index.js",
   "@types": "dist/index.d.ts",
   "bin": "./dist/bin/compile-typescript-docs.js",


### PR DESCRIPTION
# Problem

- Using TypeScript 4.7.x there are error messages of the form `Error: Debug Failure. False expression: Non-string value passed to `ts.resolveTypeReferenceDirective`, likely by a wrapping package working with an outdated `resolveTypeReferenceDirectives` signature. This is probably not a problem in TS itself.`
- Upgrading to the latest `ts-node` fixes this
- `ts-node` is currently pinned to a specific version to avoid issues extracting the line numbers from the error messages

# Solution

- Upgrade and unpin `ts-node`
- Extract the lines with errors from the newly added `diagnostics` property on `TSNode.TSError` instead of trying to parse the error message (which has been really fragile)