### PR TITLE
Support exports in package json

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,9 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.2.2]
+## Unreleased
 ### Changed
 - Unpinned `ts-node` dependency to fix issues with the most recent TypeScript versions (required the extraction of the line numbers of compilation errors to be changed)
+
+### Added
+- Support for `exports` in `package.json` including wildcard subpaths
 
 ## [2.2.1]
 ### Added

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-### Changed
-- Unpinned `ts-node` dependency to fix issues with the most recent TypeScript versions (required the extraction of the line numbers of compilation errors to be changed)
-
 ### Added
 - Support for `exports` in `package.json` including wildcard subpaths
+
+## [2.2.2]
+### Changed
+- Unpinned `ts-node` dependency to fix issues with the most recent TypeScript versions (required the extraction of the line numbers of compilation errors to be changed)
 
 ## [2.2.1]
 ### Added

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The selected markdown files are searched for `TypeScript` code blocks marked lik
 ```
 ````
 
-These code blocks are extracted and any imports from the current project are replaced with an import of the `main` file from `package.json` (e.g. `import { compileSnippets } from 'typescript-docs-verifier'` would be replaced with `import { compileSnippets } from './dist/index'` for this project).
+These code blocks are extracted and any imports from the current project are replaced with an import of the `main` or `exports` file (see below) from `package.json` (e.g. `import { compileSnippets } from 'typescript-docs-verifier'` would be replaced with `import { compileSnippets } from './dist/index'` for this project).
 
 Each code snippet is compiled (but not run) and any compilation errors are reported. Code snippets must compile independently from any other code snippets in the file.
 
@@ -96,6 +96,36 @@ compileSnippets(inputFiles)
   .catch((error) => {
     console.error('Error compiling TypeScript snippets', error)
   })
+```
+
+## `exports` resolution
+
+The [`exports` property of `package.json`](https://nodejs.org/api/packages.html#exports) is rather complex. Currently this library does not support [SubPath exports](https://nodejs.org/api/packages.html#subpath-exports) and will always prefer the `require` conditional export to the `import` conditional export (since ESM support in TypeScript is still experimental at this time). Supported `exports` patterns at the current time are:
+
+```json
+{
+  exports: "./path/to/file.js"
+}
+
+{
+  exports: {
+    ".": "./path/to/file.js"
+  }
+}
+
+{
+  exports: {
+    "require|node-addons|node|default": "./path/to/file.js"
+  }
+}
+
+{
+  exports: {
+    "require|node-addons|node|default": {
+      ".": "./path/to/file.js"
+    }
+  }
+}
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -98,36 +98,6 @@ compileSnippets(inputFiles)
   })
 ```
 
-## `exports` resolution
-
-The [`exports` property of `package.json`](https://nodejs.org/api/packages.html#exports) is rather complex. Currently this library does not support [SubPath exports](https://nodejs.org/api/packages.html#subpath-exports) and will always prefer the `require` conditional export to the `import` conditional export (since ESM support in TypeScript is still experimental at this time). Supported `exports` patterns at the current time are:
-
-```json
-{
-  exports: "./path/to/file.js"
-}
-
-{
-  exports: {
-    ".": "./path/to/file.js"
-  }
-}
-
-{
-  exports: {
-    "require|node-addons|node|default": "./path/to/file.js"
-  }
-}
-
-{
-  exports: {
-    "require|node-addons|node|default": {
-      ".": "./path/to/file.js"
-    }
-  }
-}
-```
-
 ## Development
 
 Run the tests:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The selected markdown files are searched for `TypeScript` code blocks marked lik
 ```
 ````
 
-These code blocks are extracted and any imports from the current project are replaced with an import of the `main` or `exports` file (see below) from `package.json` (e.g. `import { compileSnippets } from 'typescript-docs-verifier'` would be replaced with `import { compileSnippets } from './dist/index'` for this project).
+These code blocks are extracted and any imports from the current project are replaced with an import of the `main` or `exports` from `package.json` (e.g. `import { compileSnippets } from 'typescript-docs-verifier'` would be replaced with `import { compileSnippets } from './dist/index'` for this project).
 
 Each code snippet is compiled (but not run) and any compilation errors are reported. Code snippets must compile independently from any other code snippets in the file.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript",
     "verify"
   ],
-  "version": "2.2.1",
+  "version": "2.2.2",
   "main": "dist/index.js",
   "@types": "dist/index.d.ts",
   "bin": "./dist/bin/compile-typescript-docs.js",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript",
     "verify"
   ],
-  "version": "2.2.2",
+  "version": "2.2.1",
   "main": "dist/index.js",
   "@types": "dist/index.d.ts",
   "bin": "./dist/bin/compile-typescript-docs.js",

--- a/src/LocalImportSubstituter.ts
+++ b/src/LocalImportSubstituter.ts
@@ -1,49 +1,122 @@
 import * as path from 'path'
-import { PackageDefinition } from './PackageInfo'
+import { ConditionalExports, PackageDefinition, PackageExports, SubpathExports } from './PackageInfo'
+
+class ExportResolver {
+  private readonly packageMain?: string
+  private readonly packageExports?: PackageExports
+
+  constructor (packageMain?: string, packageExports?: PackageExports) {
+    this.packageMain = packageMain
+    this.packageExports = packageExports
+  }
+
+  private findHighestPriorityExports (): SubpathExports {
+    const conditionalExports = this.packageExports as ConditionalExports
+
+    const conditionalExportEntry = conditionalExports['node-addons'] ??
+      conditionalExports.node ??
+      conditionalExports.require ??
+      conditionalExports.default
+
+    if (conditionalExportEntry) {
+      return conditionalExportEntry
+    }
+
+    return this.packageExports as SubpathExports
+  }
+
+  stripSuffix (filePath: string): string {
+    return filePath.replace(/\.(ts|js)$/, '')
+  }
+
+  resolveExportPath (path?: string): string {
+    if (!this.packageExports) {
+      const packageMain = this.packageMain
+
+      if (!packageMain) {
+        throw new Error('Failed to find main or exports entry in package.json')
+      }
+
+      return path ?? this.stripSuffix(packageMain)
+    }
+
+    const subpathExports = this.findHighestPriorityExports()
+
+    if (!path) {
+      if (typeof subpathExports === 'string') {
+        return this.stripSuffix(subpathExports)
+      }
+
+      const rootExport = subpathExports['.']
+
+      if (!rootExport) {
+        throw new Error('No "." value found in package.json exports entry')
+      }
+      return this.stripSuffix(rootExport)
+    }
+
+    // TODO: match subpathExports against provided subpath
+    throw new Error(`No package.json exports entry found matching subpath ${path}`)
+  }
+}
 
 export class LocalImportSubstituter {
   private readonly packageName: string
   private readonly packageRoot: string
-  private readonly pathToPackageMain: string
+  private readonly exportResolver: ExportResolver
+  // private readonly pathToPackageMain: string
 
   constructor (packageDefinition: PackageDefinition) {
     this.packageName = packageDefinition.name
     this.packageRoot = packageDefinition.packageRoot
-    const packageFile = LocalImportSubstituter.resolvePathToPackageFile(packageDefinition)
+    // const packageFile =
+    //   LocalImportSubstituter.resolvePathToPackageFile(packageDefinition)
 
-    this.pathToPackageMain = path.join(packageDefinition.packageRoot, packageFile.replace(/\.(ts|js)$/, ''))
+    this.exportResolver = new ExportResolver(packageDefinition.main, packageDefinition.exports)
+
+    // this.pathToPackageMain = path.join(
+    //   packageDefinition.packageRoot,
+    //   packageFile.replace(/\.(ts|js)$/, '')
+    // )
   }
 
-  private static resolveExportsValue (exportsEntry?: string | Record<string, string | undefined>): string | null {
-    if (typeof exportsEntry === 'undefined') {
-      return null
-    }
+  // private static resolveExportsValue (
+  //   exportsEntry?: string | Record<string, string | undefined>
+  // ): string | null {
+  //   if (typeof exportsEntry === 'undefined') {
+  //     return null
+  //   }
 
-    if (typeof exportsEntry === 'string') {
-      return exportsEntry
-    }
+  //   if (typeof exportsEntry === 'string') {
+  //     return exportsEntry
+  //   }
 
-    return exportsEntry?.['.'] ?? null
-  }
+  //   return exportsEntry?.['.'] ?? null
+  // }
 
-  private static resolvePathToPackageFile (packageDefinition: PackageDefinition): string {
-    if (typeof packageDefinition.exports === 'string') {
-      return packageDefinition.exports
-    }
+  // private static resolvePathToPackageFile (packageDefinition: PackageDefinition): string {
+  //   if (typeof packageDefinition.exports === 'string') {
+  //     return packageDefinition.exports
+  //   }
 
-    const packageMainFile = packageDefinition.exports?.['.'] ??
-        LocalImportSubstituter.resolveExportsValue(packageDefinition.exports?.['node-addons']) ??
-        LocalImportSubstituter.resolveExportsValue(packageDefinition.exports?.node) ??
-        LocalImportSubstituter.resolveExportsValue(packageDefinition.exports?.require) ??
-        LocalImportSubstituter.resolveExportsValue(packageDefinition.exports?.default) ??
-        packageDefinition.main
+  //   const subpathExports = packageDefinition.exports as SubpathExports
+  //   const conditionalExports = packageDefinition.exports as ConditionalExports
 
-    if (typeof packageMainFile !== 'string') {
-      throw new Error('Failed to find a valid main or exports entry in package.json file')
-    }
+  //   const packageMainFile = subpathExports?.['.' as SubpathPattern] ??
+  //       LocalImportSubstituter.resolveExportsValue(conditionalExports?.['node-addons']) ??
+  //       LocalImportSubstituter.resolveExportsValue(conditionalExports?.node) ??
+  //       LocalImportSubstituter.resolveExportsValue(conditionalExports?.require) ??
+  //       LocalImportSubstituter.resolveExportsValue(conditionalExports?.default) ??
+  //       packageDefinition.main
 
-    return packageMainFile
-  }
+  //   if (typeof packageMainFile !== 'string') {
+  //     throw new Error(
+  //       'Failed to find a valid main or exports entry in package.json file'
+  //     )
+  //   }
+
+  //   return packageMainFile
+  // }
 
   substituteLocalPackageImports (code: string) {
     const escapedPackageName = this.packageName.replace(/\\/g, '\\/')
@@ -64,11 +137,21 @@ export class LocalImportSubstituter {
 
       const prefix = line.substring(0, index)
 
-      if (subPath) {
-        return `${prefix}${openQuote}${this.packageRoot}${subPath}${closeQuote}`
-      }
+      const resolvedExportPath = this.exportResolver.resolveExportPath(subPath)
 
-      return `${prefix}${openQuote}${this.pathToPackageMain}${closeQuote}`
+      const fullExportPath = path.join(this.packageRoot, resolvedExportPath)
+      return `${prefix}${openQuote}${fullExportPath}${closeQuote}`
+
+      //   if (subPath) {
+      //     const matchedSubPath = this.exportResolver.resolveExportPath(subPath)
+
+      //     if (!matchedSubPath) {
+      //       throw new Error(`Unable to find matching subpath export in package JSON exports property for path ${matchedSubPath}`)
+      //     }
+      //     return `${prefix}${openQuote}${this.packageRoot}${matchedSubPath}${closeQuote}`
+      //   }
+
+      //   return `${prefix}${openQuote}${this.pathToPackageMain}${closeQuote}`
     })
     return localisedLines.join('\n')
   }

--- a/src/LocalImportSubstituter.ts
+++ b/src/LocalImportSubstituter.ts
@@ -9,8 +9,40 @@ export class LocalImportSubstituter {
   constructor (packageDefinition: PackageDefinition) {
     this.packageName = packageDefinition.name
     this.packageRoot = packageDefinition.packageRoot
-    const mainImport = packageDefinition.main.replace(/\.(ts|js)$/, '')
-    this.pathToPackageMain = path.join(packageDefinition.packageRoot, mainImport)
+    const packageFile = LocalImportSubstituter.resolvePathToPackageFile(packageDefinition)
+
+    this.pathToPackageMain = path.join(packageDefinition.packageRoot, packageFile.replace(/\.(ts|js)$/, ''))
+  }
+
+  private static resolveExportsValue (exportsEntry?: string | Record<string, string | undefined>): string | null {
+    if (typeof exportsEntry === 'undefined') {
+      return null
+    }
+
+    if (typeof exportsEntry === 'string') {
+      return exportsEntry
+    }
+
+    return exportsEntry?.['.'] ?? null
+  }
+
+  private static resolvePathToPackageFile (packageDefinition: PackageDefinition): string {
+    if (typeof packageDefinition.exports === 'string') {
+      return packageDefinition.exports
+    }
+
+    const packageMainFile = packageDefinition.exports?.['.'] ??
+        LocalImportSubstituter.resolveExportsValue(packageDefinition.exports?.['node-addons']) ??
+        LocalImportSubstituter.resolveExportsValue(packageDefinition.exports?.node) ??
+        LocalImportSubstituter.resolveExportsValue(packageDefinition.exports?.require) ??
+        LocalImportSubstituter.resolveExportsValue(packageDefinition.exports?.default) ??
+        packageDefinition.main
+
+    if (typeof packageMainFile !== 'string') {
+      throw new Error('Failed to find a valid main or exports entry in package.json file')
+    }
+
+    return packageMainFile
   }
 
   substituteLocalPackageImports (code: string) {

--- a/src/PackageInfo.ts
+++ b/src/PackageInfo.ts
@@ -3,8 +3,9 @@ import * as fsExtra from 'fs-extra'
 
 export type PackageDefinition = {
   readonly name: string
-  readonly main: string
+  readonly main?: string
   readonly packageRoot: string
+  readonly exports?: string | Record<string, string | Record<string, string | undefined> | undefined>
 }
 
 const searchParentsForPackage = async (currentPath: string): Promise<string> => {
@@ -35,6 +36,7 @@ export class PackageInfo {
     return {
       name: packageInfo.name,
       main: packageInfo.main,
+      exports: packageInfo.exports,
       packageRoot
     }
   }

--- a/src/PackageInfo.ts
+++ b/src/PackageInfo.ts
@@ -10,9 +10,14 @@ type ConditionalExportKeys =
   | 'require'
   | 'default'
 
-export type SubpathExports = string | { [key in SubpathPattern]?: string }
+export type SubpathExports = {
+  [key in SubpathPattern]?: string | null | {
+    [key in ConditionalExportKeys]?: string
+  }
+}
+
 export type ConditionalExports = {
-  [key in ConditionalExportKeys]?: string | SubpathExports
+  [key in ConditionalExportKeys]?: string | null
 }
 
 export type PackageExports =

--- a/src/PackageInfo.ts
+++ b/src/PackageInfo.ts
@@ -1,11 +1,30 @@
 import * as path from 'path'
 import * as fsExtra from 'fs-extra'
 
+export type SubpathPattern = '.' | string
+
+type ConditionalExportKeys =
+  | 'node-addons'
+  | 'node'
+  | 'import'
+  | 'require'
+  | 'default'
+
+export type SubpathExports = string | { [key in SubpathPattern]?: string }
+export type ConditionalExports = {
+  [key in ConditionalExportKeys]?: string | SubpathExports
+}
+
+export type PackageExports =
+  | string
+  | SubpathExports
+  | ConditionalExports
+
 export type PackageDefinition = {
   readonly name: string
   readonly main?: string
   readonly packageRoot: string
-  readonly exports?: string | Record<string, string | Record<string, string | undefined> | undefined>
+  readonly exports?: PackageExports
 }
 
 const searchParentsForPackage = async (currentPath: string): Promise<string> => {

--- a/test/LocalImportSubstituterSpec.ts
+++ b/test/LocalImportSubstituterSpec.ts
@@ -2,6 +2,12 @@
 import { expect } from 'chai'
 import { LocalImportSubstituter } from '../src/LocalImportSubstituter'
 
+const defaultPackageInfo = {
+  name: 'my-package',
+  main: 'index.ts',
+  packageRoot: '/path/to/package'
+}
+
 const scenarios = [{
   importLine: `import something from 'awesome'`,
   expected: `import something from '/path/to/package/index'`,
@@ -18,6 +24,78 @@ const scenarios = [{
   importLine: `import something from "awesome"      `,
   expected: `import something from "/path/to/package/index"`,
   name: 'trailing whitespace'
+}, {
+  importLine: `import something from 'awesome'`,
+  expected: `import something from '/path/to/package/main'`,
+  packageInfo: {
+    exports: 'main.ts'
+  },
+  name: 'where exports is a string'
+}, {
+  importLine: `import something from 'awesome'`,
+  expected: `import something from '/path/to/package/main'`,
+  packageInfo: {
+    exports: {
+      '.': 'main.ts'
+    }
+  },
+  name: 'where exports is { ".": "{some-file}" }'
+}, {
+  importLine: `import something from 'awesome'`,
+  expected: `import something from '/path/to/package/main'`,
+  packageInfo: {
+    exports: {
+      'node-addons': 'main.ts'
+    }
+  },
+  name: 'where exports is { "node-addons": "{some-file}" }'
+}, {
+  importLine: `import something from 'awesome'`,
+  expected: `import something from '/path/to/package/main'`,
+  packageInfo: {
+    exports: {
+      node: 'main.ts'
+    }
+  },
+  name: 'where exports is { "node": "{some-file}" }'
+}, {
+  importLine: `import something from 'awesome'`,
+  expected: `import something from '/path/to/package/main'`,
+  packageInfo: {
+    exports: {
+      require: 'main.ts'
+    }
+  },
+  name: 'where exports is { "require": "{some-file}" }'
+}, {
+  importLine: `import something from 'awesome'`,
+  expected: `import something from '/path/to/package/main'`,
+  packageInfo: {
+    exports: {
+      default: 'main.ts'
+    }
+  },
+  name: 'where exports is { "default": "{some-file}" }'
+}, {
+  importLine: `import something from 'awesome'`,
+  expected: `import something from '/path/to/package/main'`,
+  packageInfo: {
+    exports: {
+      ".": 'main.ts'
+    }
+  },
+  name: 'where exports is { "require": { ".": "some-file" }" }'
+}, {
+  importLine: `import something from 'awesome'`,
+  expected: `import something from '/path/to/package/main'`,
+  packageInfo: {
+    exports: {
+      default: {
+        ".": 'main.ts'
+      }
+    }
+  },
+  name: 'where exports is { "require": { "default": { ".": "some-file" } }" }'
 }, {
   importLine: `import something from '@my-scope/awesome'`,
   expected: `import something from '/path/to/package/index'`,
@@ -46,11 +124,7 @@ const scenarios = [{
 
 describe('LocalImportSubstituter', () => {
   it('does not change imports for different packages', () => {
-    const substituter = new LocalImportSubstituter({
-      name: 'my-package',
-      main: 'index.ts',
-      packageRoot: '/path/to/package'
-    })
+    const substituter = new LocalImportSubstituter(defaultPackageInfo)
 
     const code = `import * as other from "package"
 
@@ -60,12 +134,43 @@ console.log('Should not be mutated')`
     expect(result).to.eql(code)
   })
 
-  scenarios.forEach(({ importLine, expected, name, packageName = 'awesome' }) => {
+  it('throws an error if main and exports are both not defined', () => {
+    expect(() => new LocalImportSubstituter({
+      name: 'my-package',
+      packageRoot: '/path/to/package'
+    })).to.throw('Failed to find a valid main or exports entry in package.json file')
+  })
+
+  it('throws an error if exports does not contain a valid entry under default', () => {
+    expect(() => new LocalImportSubstituter({
+      name: 'my-package',
+      packageRoot: '/path/to/package',
+      exports: {
+        default: {
+          'some/specific/path': 'main.ts'
+        }
+      }
+    })).to.throw('Failed to find a valid main or exports entry in package.json file')
+  })
+
+  it('throws an error if exports contains only an undefined value under default', () => {
+    expect(() => new LocalImportSubstituter({
+      name: 'my-package',
+      packageRoot: '/path/to/package',
+      exports: {
+        default: {
+          '.': undefined
+        }
+      }
+    })).to.throw('Failed to find a valid main or exports entry in package.json file')
+  })
+
+  scenarios.forEach(({ importLine, expected, name, packageName = 'awesome', packageInfo = {} }) => {
     it(`localises imports with ${name}`, () => {
       const substituter = new LocalImportSubstituter({
-        name: packageName,
-        main: 'index.ts',
-        packageRoot: '/path/to/package'
+        ...defaultPackageInfo,
+        ...packageInfo,
+        name: packageName
       })
 
       const code = `

--- a/test/LocalImportSubstituterSpec.ts
+++ b/test/LocalImportSubstituterSpec.ts
@@ -147,7 +147,7 @@ console.log('Should not be mutated')`
       packageRoot: '/path/to/package',
       exports: {
         default: {
-          'some/specific/path': 'main.ts'
+          './some/specific/path': './main.ts'
         }
       }
     })).to.throw('Failed to find a valid main or exports entry in package.json file')

--- a/test/TypeScriptDocsVerifierSpec.ts
+++ b/test/TypeScriptDocsVerifierSpec.ts
@@ -401,6 +401,78 @@ console.log('This line is also OK');
     )
 
     verify.it(
+      'localises imports of the current package using exports.require if it exists', async () => {
+        const snippet = `
+          import { MyClass } from '${defaultPackageJson.name}'
+          const instance = new MyClass()
+          instance.doStuff()`
+        const mainFile = {
+          name: `${defaultPackageJson.main}`,
+          contents: `
+            export class MyClass {
+              doStuff (): void {
+                return
+              }
+            }`
+        }
+        const packageJson = {
+          ...defaultPackageJson,
+          exports: {
+            require: defaultPackageJson.main
+          },
+          main: 'some/other/file.js'
+        }
+
+        const typeScriptMarkdown = wrapSnippet(snippet)
+        await createProject({ markdownFiles: [{ name: 'README.md', contents: typeScriptMarkdown }], mainFile, packageJson })
+        return await TypeScriptDocsVerifier.compileSnippets()
+          .should.eventually.eql([{
+            file: 'README.md',
+            index: 1,
+            snippet,
+            linesWithErrors: []
+          }])
+      }
+    )
+
+    verify.it(
+      'localises imports of the current package using exports.require["."] if it exists', async () => {
+        const snippet = `
+          import { MyClass } from '${defaultPackageJson.name}'
+          const instance = new MyClass()
+          instance.doStuff()`
+        const mainFile = {
+          name: `${defaultPackageJson.main}`,
+          contents: `
+            export class MyClass {
+              doStuff (): void {
+                return
+              }
+            }`
+        }
+        const packageJson = {
+          ...defaultPackageJson,
+          exports: {
+            require: {
+              '.': defaultPackageJson.main
+            }
+          },
+          main: 'some/other/file.js'
+        }
+
+        const typeScriptMarkdown = wrapSnippet(snippet)
+        await createProject({ markdownFiles: [{ name: 'README.md', contents: typeScriptMarkdown }], mainFile, packageJson })
+        return await TypeScriptDocsVerifier.compileSnippets()
+          .should.eventually.eql([{
+            file: 'README.md',
+            index: 1,
+            snippet,
+            linesWithErrors: []
+          }])
+      }
+    )
+
+    verify.it(
       'localises imports of files within the current package', async () => {
         const sourceFolder = Gen.word()
         const snippet = `


### PR DESCRIPTION
Addresses #17 

# Problem

- `exports` in `package.json` aren't supported (see https://nodejs.org/dist/latest-v16.x/docs/api/packages.html#package-entry-points)

# Solution

- Use `exports` if present and fall back to `main` only if `exports` does not exist
- Support wildcard `*` characters in subpaths

## Notes

- Also update the `ts-node` dependency to simplify line number resolution.