### PR TITLE
Compile docs in the project directory to ensure dependencies are resolved correctly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support for `exports` in `package.json` including wildcard subpaths
 
+### Changed
+- Compile documentation snippets in the project folder so that dependent packages can be resolved reliably even in nested projects
+
 ## [2.2.2]
 ### Changed
 - Unpinned `ts-node` dependency to fix issues with the most recent TypeScript versions (required the extraction of the line numbers of compilation errors to be changed)

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,3 @@
-import * as os from 'os'
 import * as path from 'path'
 import { PackageInfo } from './src/PackageInfo'
 import { SnippetCompiler, SnippetCompilationResult } from './src/SnippetCompiler'
@@ -16,8 +15,8 @@ const wrapIfString = (arrayOrString: string[] | string) => {
 }
 
 export async function compileSnippets (markdownFileOrFiles: string | string[] = DEFAULT_FILES): Promise<SnippetCompilationResult[]> {
-  const compiledDocsFolder = path.join(os.tmpdir(), 'compiled-docs')
   const packageDefinition = await PackageInfo.read()
+  const compiledDocsFolder = path.join(packageDefinition.packageRoot, '.tmp-compiled-docs')
   const compiler = new SnippetCompiler(compiledDocsFolder, packageDefinition)
   const fileArray = wrapIfString(markdownFileOrFiles)
   const results = await compiler.compileSnippets(fileArray)


### PR DESCRIPTION
# Problem

- Project dependencies from `node_modules` aren't resolved correctly for nested projects
- This is because we generate the snippets outside the project tree and symlink `node_modules`

# Solution

- Revert to generating the code snippets in the project tree