### PR TITLE
Add a --project flag that overrides the tsconfig.json options

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- A new `--project` option that overrides the `tsconfig.json` file to be used when compiling snippets
+
 ## [2.3.1]
 ### Changed
 - Update dependencies

--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ Individual code blocks can be ignored by preceding them with a `<!-- ts-docs-ver
 ## Script usage
 
 ```bash
-node_modules/.bin/typescript-docs-verifier [--input-files <markdown-files-to-test>]
+node_modules/.bin/typescript-docs-verifier [--input-files <markdown-files-to-test>] [--project <path-to-tsconfig-file>]
 ```
 
 * `--input-files` is optional and defaults to `README.md`.
+* `--project` is optional and defaults to the `tsconfig.json` file in the package root.
 * Any compilation errors will be reported on the console.
 * The exit code is 1 if there are any compilation errors and 0 otherwise.
 
@@ -60,7 +61,8 @@ import { compileSnippets, SnippetCompilationResult } from 'typescript-docs-verif
 import * as http from 'http'
 
 const inputFiles = ['README', 'examples.md'] // defaults to 'README.md' if not provided
-compileSnippets(inputFiles)
+const tsconfigPath = 'docs-tsconfig.json' // defaults to the 'tsconfig.json' file in the package root
+compileSnippets(inputFiles, tsconfigPath)
   .then((results: SnippetCompilationResult[]) => {
     results.forEach((result: SnippetCompilationResult) => {
       if (result.error) {
@@ -82,7 +84,8 @@ compileSnippets(inputFiles)
 const { compileSnippets } = require('typescript-docs-verifier')
 
 const inputFiles = ['README.md', 'examples.md'] // defaults to 'README.md' if not provided
-compileSnippets(inputFiles)
+const tsconfigPath = 'docs-tsconfig.json' // defaults to the 'tsconfig.json' file in the package root
+compileSnippets(inputFiles, tsconfigPath)
   .then((results) => {
     results.forEach((result) => {
       if (result.error) {

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ node_modules/.bin/typescript-docs-verifier [--input-files <markdown-files-to-tes
 import { compileSnippets, SnippetCompilationResult } from 'typescript-docs-verifier'
 import * as http from 'http'
 
-const inputFiles = ['README', 'examples.md'] // defaults to 'README.md' if not provided
+const markdownFiles = ['README', 'examples.md'] // defaults to 'README.md' if not provided
 const tsconfigPath = 'docs-tsconfig.json' // defaults to the 'tsconfig.json' file in the package root
-compileSnippets(inputFiles, tsconfigPath)
+compileSnippets({ markdownFiles, project: tsconfigPath })
   .then((results: SnippetCompilationResult[]) => {
     results.forEach((result: SnippetCompilationResult) => {
       if (result.error) {
@@ -83,9 +83,9 @@ compileSnippets(inputFiles, tsconfigPath)
 ```javascript
 const { compileSnippets } = require('typescript-docs-verifier')
 
-const inputFiles = ['README.md', 'examples.md'] // defaults to 'README.md' if not provided
+const markdownFiles = ['README.md', 'examples.md'] // defaults to 'README.md' if not provided
 const tsconfigPath = 'docs-tsconfig.json' // defaults to the 'tsconfig.json' file in the package root
-compileSnippets(inputFiles, tsconfigPath)
+compileSnippets({ markdownFiles, project: tsconfigPath })
   .then((results) => {
     results.forEach((result) => {
       if (result.error) {

--- a/bin/compile-typescript-docs.ts
+++ b/bin/compile-typescript-docs.ts
@@ -5,13 +5,20 @@ import chalk from "chalk";
 import * as yargs from "yargs";
 import * as TypeScriptDocsVerifier from "../index";
 
-const cliOptions = yargs.option("input-files", {
-  description: "The list of input files to be processed",
-  array: true,
-  default: ["README.md"],
-});
+const cliOptions = yargs
+  .option("input-files", {
+    description: "The list of input files to be processed",
+    array: true,
+    default: ["README.md"],
+  })
+  .option("project", {
+    description:
+      "The path (relative to the package root) to the tsconfig.json file to use when compiling snippets (defaults to the `tsconfig.json` in the package root)",
+    string: true,
+    requiresArg: false,
+  });
 
-const inputFiles = cliOptions.parseSync()["input-files"];
+const { "input-files": inputFiles, project } = cliOptions.parseSync();
 
 const spinner = ora();
 spinner
@@ -38,7 +45,10 @@ const formatError = (error: Error) =>
   "  " + error.message.split("\n").join("\n      ");
 
 const doCompilation = async () => {
-  const results = await TypeScriptDocsVerifier.compileSnippets(inputFiles);
+  const results = await TypeScriptDocsVerifier.compileSnippets(
+    inputFiles,
+    project
+  );
   spinner.info(`Found ${results.length} TypeScript snippets`).start();
   results.forEach((result) => {
     if (result.error) {

--- a/bin/compile-typescript-docs.ts
+++ b/bin/compile-typescript-docs.ts
@@ -45,10 +45,10 @@ const formatError = (error: Error) =>
   "  " + error.message.split("\n").join("\n      ");
 
 const doCompilation = async () => {
-  const results = await TypeScriptDocsVerifier.compileSnippets(
-    inputFiles,
-    project
-  );
+  const results = await TypeScriptDocsVerifier.compileSnippets({
+    markdownFiles: inputFiles,
+    project,
+  });
   spinner.info(`Found ${results.length} TypeScript snippets`).start();
   results.forEach((result) => {
     if (result.error) {

--- a/index.ts
+++ b/index.ts
@@ -18,14 +18,19 @@ const wrapIfString = (arrayOrString: string[] | string) => {
 };
 
 export async function compileSnippets(
-  markdownFileOrFiles: string | string[] = DEFAULT_FILES
+  markdownFileOrFiles: string | string[] = DEFAULT_FILES,
+  project?: string
 ): Promise<SnippetCompilationResult[]> {
   const packageDefinition = await PackageInfo.read();
   const compiledDocsFolder = path.join(
     packageDefinition.packageRoot,
     ".tmp-compiled-docs"
   );
-  const compiler = new SnippetCompiler(compiledDocsFolder, packageDefinition);
+  const compiler = new SnippetCompiler(
+    compiledDocsFolder,
+    packageDefinition,
+    project
+  );
   const fileArray = wrapIfString(markdownFileOrFiles);
   const results = await compiler.compileSnippets(fileArray);
   return results;

--- a/index.ts
+++ b/index.ts
@@ -9,18 +9,36 @@ export { SnippetCompilationResult } from "./src/SnippetCompiler";
 
 const DEFAULT_FILES = ["README.md"];
 
-const wrapIfString = (arrayOrString: string[] | string) => {
-  if (Array.isArray(arrayOrString)) {
-    return arrayOrString;
-  } else {
-    return [arrayOrString];
+const parseArguments = (args: CompileSnippetsArguments) => {
+  if (typeof args === "string") {
+    return {
+      markdownFiles: [args],
+    };
   }
+  if (Array.isArray(args)) {
+    return {
+      markdownFiles: args,
+    };
+  }
+  return {
+    project: args.project,
+    markdownFiles: args.markdownFiles ?? DEFAULT_FILES,
+  };
 };
 
+export type CompileSnippetsArguments =
+  | string
+  | string[]
+  | {
+      markdownFiles?: string[];
+      project?: string;
+    };
+
 export async function compileSnippets(
-  markdownFileOrFiles: string | string[] = DEFAULT_FILES,
-  project?: string
+  args: CompileSnippetsArguments = DEFAULT_FILES
 ): Promise<SnippetCompilationResult[]> {
+  const { project, markdownFiles } = parseArguments(args);
+
   const packageDefinition = await PackageInfo.read();
   const compiledDocsFolder = path.join(
     packageDefinition.packageRoot,
@@ -31,7 +49,6 @@ export async function compileSnippets(
     packageDefinition,
     project
   );
-  const fileArray = wrapIfString(markdownFileOrFiles);
-  const results = await compiler.compileSnippets(fileArray);
+  const results = await compiler.compileSnippets(markdownFiles);
   return results;
 }

--- a/src/SnippetCompiler.ts
+++ b/src/SnippetCompiler.ts
@@ -27,18 +27,26 @@ export class SnippetCompiler {
 
   constructor(
     private readonly workingDirectory: string,
-    private readonly packageDefinition: PackageDefinition
+    private readonly packageDefinition: PackageDefinition,
+    project?: string
   ) {
     const configOptions = SnippetCompiler.loadTypeScriptConfig(
-      packageDefinition.packageRoot
+      packageDefinition.packageRoot,
+      project
     );
     this.compiler = TSNode.create(configOptions.config as TSNode.CreateOptions);
   }
 
-  private static loadTypeScriptConfig(packageRoot: string): {
+  private static loadTypeScriptConfig(
+    packageRoot: string,
+    project?: string
+  ): {
     config: unknown;
   } {
-    const typeScriptConfig = tsconfig.loadSync(packageRoot);
+    const fullProjectPath = path.join(packageRoot, project ?? "");
+    const { base, dir } = path.parse(fullProjectPath);
+
+    const typeScriptConfig = tsconfig.loadSync(dir, base);
     if (typeScriptConfig?.config?.compilerOptions) {
       typeScriptConfig.config.compilerOptions.noUnusedLocals = false;
     }

--- a/test/TypeScriptDocsVerifierSpec.ts
+++ b/test/TypeScriptDocsVerifierSpec.ts
@@ -998,6 +998,28 @@ console.log('This line is also OK');
     );
 
     verify.it(
+      "uses the default settings if an empty object is supplied",
+      genSnippet,
+      Gen.string,
+      async (snippet) => {
+        const typeScriptMarkdown = wrapSnippet(snippet);
+        await createProject({
+          markdownFiles: [{ name: "README.md", contents: typeScriptMarkdown }],
+        });
+        return await TypeScriptDocsVerifier.compileSnippets(
+          {}
+        ).should.eventually.eql([
+          {
+            file: "README.md",
+            index: 1,
+            snippet,
+            linesWithErrors: [],
+          },
+        ]);
+      }
+    );
+
+    verify.it(
       "overrides the tsconfig.json path when the --project flag is used",
       async () => {
         const snippet = `
@@ -1034,10 +1056,10 @@ console.log('This line is also OK');
           tsconfigJson
         );
 
-        return await TypeScriptDocsVerifier.compileSnippets(
-          "DOCS.md",
-          tsconfigFilename
-        ).should.eventually.eql([
+        return await TypeScriptDocsVerifier.compileSnippets({
+          markdownFiles: ["DOCS.md"],
+          project: tsconfigFilename,
+        }).should.eventually.eql([
           {
             file: "DOCS.md",
             index: 1,
@@ -1087,10 +1109,10 @@ console.log('This line is also OK');
           tsconfigJson
         );
 
-        return await TypeScriptDocsVerifier.compileSnippets(
-          "DOCS.md",
-          path.join(tsconfigDirectory, tsconfigFile)
-        ).should.eventually.eql([
+        return await TypeScriptDocsVerifier.compileSnippets({
+          project: path.join(tsconfigDirectory, tsconfigFile),
+          markdownFiles: ["DOCS.md"],
+        }).should.eventually.eql([
           {
             file: "DOCS.md",
             index: 1,


### PR DESCRIPTION
Addresses #22 

- Add a `--project` flag to set the TypeScript configuration file for snippet compilation
- Useful if clients want to use different compilation options when compiling documentation snippets