### PR TITLE
Fixes for windows

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ compileSnippets({ markdownFiles, project: tsconfigPath })
       }
     })
   })
-  .catch((error) => {
+  .catch((error: unknown) => {
     console.error('Error compiling TypeScript snippets', error)
   })
 ```

--- a/bin/compile-typescript-docs.ts
+++ b/bin/compile-typescript-docs.ts
@@ -9,6 +9,7 @@ const cliOptions = yargs
   .option("input-files", {
     description: "The list of input files to be processed",
     array: true,
+    string: true,
     default: ["README.md"],
   })
   .option("project", {

--- a/src/CodeBlockExtractor.ts
+++ b/src/CodeBlockExtractor.ts
@@ -3,7 +3,7 @@ import * as fsExtra from "fs-extra";
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class CodeBlockExtractor {
   static readonly TYPESCRIPT_CODE_PATTERN =
-    /(?<!(?:<!--\s*ts-docs-verifier:ignore\s*-->[\r\n]*))(?:```(?:(?:typescript)|(?:ts))\n)((?:\n|.)*?)(?:(?=```))/gi;
+    /(?<!(?:<!--\s*ts-docs-verifier:ignore\s*-->[\r?\n]*))(?:```(?:(?:typescript)|(?:ts))\r?\n)((?:\r?\n|.)*?)(?:(?=```))/gi;
 
   /* istanbul ignore next */
   private constructor() {

--- a/src/LocalImportSubstituter.ts
+++ b/src/LocalImportSubstituter.ts
@@ -160,7 +160,7 @@ export class LocalImportSubstituter {
 
       const fullExportPath = path
         .join(this.packageRoot, resolvedExportPath)
-        .replace(/\\/g, "\\");
+        .replace(/\\/g, "\\\\");
       return `${prefix}${openQuote}${fullExportPath}${closeQuote}`;
     });
     return localisedLines.join("\n");

--- a/src/LocalImportSubstituter.ts
+++ b/src/LocalImportSubstituter.ts
@@ -158,7 +158,9 @@ export class LocalImportSubstituter {
 
       const resolvedExportPath = this.exportResolver.resolveExportPath(subPath);
 
-      const fullExportPath = path.join(this.packageRoot, resolvedExportPath);
+      const fullExportPath = path
+        .join(this.packageRoot, resolvedExportPath)
+        .replace(/\\/g, "\\");
       return `${prefix}${openQuote}${fullExportPath}${closeQuote}`;
     });
     return localisedLines.join("\n");

--- a/src/SnippetCompiler.ts
+++ b/src/SnippetCompiler.ts
@@ -63,10 +63,6 @@ export class SnippetCompiler {
     try {
       await this.cleanWorkingDirectory();
       await fsExtra.ensureDir(this.workingDirectory);
-      await fsExtra.symlink(
-        path.join(this.packageDefinition.packageRoot, "node_modules"),
-        path.join(this.workingDirectory, "node_modules")
-      );
       const examples = await this.extractAllCodeBlocks(documentationFiles);
       return await Promise.all(
         examples.map(async (example) => await this.testCodeCompilation(example))


### PR DESCRIPTION
Addresses #26 

# Problem

- On Windows, no snippets are found in the input files

# Solution

- Fix snippet search pattern to support both `\r\n` and `\n` new lines
- Escape `\` in file import paths when substituting imports
- Remove symlinking of `node_modules` as this gives me permission errors on Windows and _shouldn't_ be needed (since we compile in a subfolder of the project and Node will traverse up the tree looking for `node_modules`)

## Notes

- Also use `unknown` for errors in docs
- Set the `input-files` CLI arg to be an array of strings