### PR TITLE
tsx support

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -25,3 +25,5 @@ jobs:
     - run: npm install
     - run: npm run build --if-present
     - run: npm test
+      env:
+        NODE_OPTIONS: "--max_old_space_size=4096"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.5.0]
+### Added
+- Support for `tsx` snippets
+
 ## [2.4.1]
 ### Changed
 - Various fixes for Windows environments

--- a/README.md
+++ b/README.md
@@ -23,12 +23,27 @@ The selected markdown files are searched for `TypeScript` code blocks marked lik
 ````Markdown
 ```typescript
 // Some TypeScript code here
+const write = 'some code';
 ```
 ````
 
 These code blocks are extracted and any imports from the current project are replaced with an import of the `main` or `exports` from `package.json` (e.g. `import { compileSnippets } from 'typescript-docs-verifier'` would be replaced with `import { compileSnippets } from './dist/index'` for this project).
 
 Each code snippet is compiled (but not run) and any compilation errors are reported. Code snippets must compile independently from any other code snippets in the file.
+
+The library can also be used to type check `.tsx` files:
+
+````Markdown
+```tsx
+import React from 'react'
+
+const SomeComponent = () => (
+  <div>
+    This is a TSX component!
+  </div>
+)
+```
+````
 
 ### Ignoring code blocks
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/fs-extra": "^9.0.13",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.59",
+    "@types/react": "^18.2.12",
     "@types/yargs": "^17.0.12",
     "@typescript-eslint/eslint-plugin": "^5.36.1",
     "@typescript-eslint/parser": "^5.36.1",
@@ -67,6 +68,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^15.1.0",
     "prettier": "^2.7.1",
+    "react": "^18.2.0",
     "typescript": "^4.7.3",
     "verify-it": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript",
     "verify"
   ],
-  "version": "2.4.1",
+  "version": "2.5.0",
   "main": "dist/index.js",
   "@types": "dist/index.d.ts",
   "bin": "./dist/bin/compile-typescript-docs.js",

--- a/src/CodeBlockExtractor.ts
+++ b/src/CodeBlockExtractor.ts
@@ -3,14 +3,16 @@ import * as fsExtra from "fs-extra";
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class CodeBlockExtractor {
   static readonly TYPESCRIPT_CODE_PATTERN =
-    /(?<!(?:<!--\s*ts-docs-verifier:ignore\s*-->[\r?\n]*))(?:```(?:(?:typescript)|(?:ts))\r?\n)((?:\r?\n|.)*?)(?:(?=```))/gi;
+    /(?<!(?:<!--\s*ts-docs-verifier:ignore\s*-->[\r?\n]*))(?:```(?:(?:typescript)|(tsx?))\r?\n)((?:\r?\n|.)*?)(?:(?=```))/gi;
 
   /* istanbul ignore next */
   private constructor() {
     //
   }
 
-  static async extract(markdownFilePath: string): Promise<string[]> {
+  static async extract(
+    markdownFilePath: string
+  ): Promise<{ code: string; type: "tsx" | "ts" }[]> {
     try {
       const contents = await CodeBlockExtractor.readFile(markdownFilePath);
       return CodeBlockExtractor.extractCodeBlocksFromMarkdown(contents);
@@ -27,10 +29,15 @@ export class CodeBlockExtractor {
     return await fsExtra.readFile(path, "utf-8");
   }
 
-  private static extractCodeBlocksFromMarkdown(markdown: string): string[] {
-    const codeBlocks: string[] = [];
-    markdown.replace(this.TYPESCRIPT_CODE_PATTERN, (_, code) => {
-      codeBlocks.push(code);
+  private static extractCodeBlocksFromMarkdown(
+    markdown: string
+  ): { code: string; type: "tsx" | "ts" }[] {
+    const codeBlocks: { code: string; type: "tsx" | "ts" }[] = [];
+    markdown.replace(this.TYPESCRIPT_CODE_PATTERN, (_, type, code) => {
+      codeBlocks.push({
+        code,
+        type: type === "tsx" ? "tsx" : "ts",
+      });
       return code;
     });
     return codeBlocks;

--- a/src/LocalImportSubstituter.ts
+++ b/src/LocalImportSubstituter.ts
@@ -102,7 +102,7 @@ class ExportResolver {
   }
 
   stripSuffix(filePath: string): string {
-    return filePath.replace(/\.(ts|js)$/, "");
+    return filePath.replace(/\.(tsx?|js)$/, "");
   }
 
   resolveExportPath(path?: string): string {

--- a/test/TypeScriptDocsVerifierSpec.ts
+++ b/test/TypeScriptDocsVerifierSpec.ts
@@ -559,7 +559,7 @@ console.log('This line is also OK');
       }
     );
 
-    verify.it.only(
+    verify.it(
       "localises imports of the current package if the package main is a tsx file",
       async () => {
         const snippet = `

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     // "lib": [],                             /* Specify library files to be included in the compilation:  */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */,
     "declaration": true /* Generates corresponding '.d.ts' file. */,
     "sourceMap": true /* Generates corresponding '.map' file. */,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */


### PR DESCRIPTION
# Problem

- No support for `tsx` snippets

# Solution

- Update the snippet search pattern to include `.tsx` snippets
- Write snippets to a `.tsx` file if they are supposed to be `tsx`
- Add tests