### PR TITLE
Force ts-node to type check code

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, 20.x]
+        node-version: [12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.5.1]
+### Added
+- Override any project-specific `ts-node` `transpileOnly` to force type checking when compiling code snippets
+
 ## [2.5.0]
 ### Added
 - Support for `tsx` snippets

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript",
     "verify"
   ],
-  "version": "2.5.0",
+  "version": "2.5.1",
   "main": "dist/index.js",
   "@types": "dist/index.d.ts",
   "bin": "./dist/bin/compile-typescript-docs.js",

--- a/src/SnippetCompiler.ts
+++ b/src/SnippetCompiler.ts
@@ -35,7 +35,11 @@ export class SnippetCompiler {
       packageDefinition.packageRoot,
       project
     );
-    this.compiler = TSNode.create(configOptions.config as TSNode.CreateOptions);
+    const tsConfig = {
+      ...(configOptions.config as TSNode.CreateOptions),
+      transpileOnly: false,
+    };
+    this.compiler = TSNode.create(tsConfig);
   }
 
   private static loadTypeScriptConfig(


### PR DESCRIPTION
Addresses #31 

- If `transpileOnly` is set in one of the TS config files, `ts-node` will not perform type checking (but does perform some syntax checks)
- Force `ts-node` to type check by setting `transpileOnly: false` when we create the compiler