### PR TITLE
Use a separate compiler instance per snippet

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [2.5.3]
+### Changed
+- Use a separate `ts-node` compiler per-snippet to ensure that compilation of snippets is independent
+
 ## [2.5.2]
 ### Removed
 - Obsolete Travis CI build badge from README

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript",
     "verify"
   ],
-  "version": "2.5.2",
+  "version": "2.5.3",
   "main": "dist/index.js",
   "@types": "dist/index.d.ts",
   "bin": {

--- a/src/SnippetCompiler.ts
+++ b/src/SnippetCompiler.ts
@@ -24,7 +24,7 @@ export type SnippetCompilationResult = {
 };
 
 export class SnippetCompiler {
-  private readonly compiler: TSNode.Service;
+  private readonly compilerConfig: TSNode.CreateOptions;
 
   constructor(
     private readonly workingDirectory: string,
@@ -35,11 +35,10 @@ export class SnippetCompiler {
       packageDefinition.packageRoot,
       project
     );
-    const tsConfig = {
+    this.compilerConfig = {
       ...(configOptions.config as TSNode.CreateOptions),
       transpileOnly: false,
     };
-    this.compiler = TSNode.create(tsConfig);
   }
 
   private static loadTypeScriptConfig(
@@ -124,7 +123,8 @@ export class SnippetCompiler {
     const id = process.hrtime.bigint().toString();
     const codeFile = path.join(this.workingDirectory, `block-${id}.${type}`);
     await fsExtra.writeFile(codeFile, code);
-    this.compiler.compile(code, codeFile);
+    const compiler = TSNode.create(this.compilerConfig);
+    compiler.compile(code, codeFile);
   }
 
   private removeTemporaryFilePaths(

--- a/test/TypeScriptDocsVerifierSpec.ts
+++ b/test/TypeScriptDocsVerifierSpec.ts
@@ -388,6 +388,31 @@ export const bob = () => (<div></div>);
       }
     );
 
+    verify.it("compiles snippets independently", async () => {
+      const snippet1 = `interface Foo { bar: 123 }`;
+      const snippet2 = `interface Foo { bar: () => void }`;
+      const typeScriptMarkdown = wrapSnippet(snippet1) + wrapSnippet(snippet2);
+      await createProject({
+        markdownFiles: [{ name: "README.md", contents: typeScriptMarkdown }],
+      });
+      return await TypeScriptDocsVerifier.compileSnippets().should.eventually.eql(
+        [
+          {
+            file: "README.md",
+            index: 1,
+            snippet: snippet1,
+            linesWithErrors: [],
+          },
+          {
+            file: "README.md",
+            index: 2,
+            snippet: snippet2,
+            linesWithErrors: [],
+          },
+        ]
+      );
+    });
+
     verify.it(
       "compiles snippets containing modules",
       genSnippet,


### PR DESCRIPTION
Addresses #30 

- It seems that the `ts-node` compiler instance accumulates state as it's run
- Use a separate compiler instance so that code blocks are evaluated independently
