### PR TITLE
Fix rootDir bugs and process compilation diagnostics correctly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [3.0.1]
+
+### Changed
+
+- Fix compilation errors when `rootDir` is used in `tsconfig.json`
+- Ensure compiler option diagnostics are reported in the error output
+
 ## [3.0.0]
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typescript",
     "verify"
   ],
-  "version": "3.0.0",
+  "version": "3.0.1",
   "main": "dist/index.js",
   "@types": "dist/index.d.ts",
   "bin": {

--- a/src/CodeCompiler.ts
+++ b/src/CodeCompiler.ts
@@ -1,4 +1,5 @@
 import ts from "typescript";
+import path from "path";
 
 const createServiceHost = (
   options: ts.CompilerOptions,
@@ -46,7 +47,10 @@ export const compile = async ({
   diagnostics: ReadonlyArray<ts.Diagnostic>;
 }> => {
   const id = process.hrtime.bigint().toString();
-  const filename = `block-${id}.${type}`;
+  const filename = path.join(
+    compilerOptions.rootDir || "",
+    `block-${id}.${type}`
+  );
 
   const fileMap = new Map<string, string>([[filename, code]]);
 
@@ -78,6 +82,7 @@ export const compile = async ({
 
     if (output.emitSkipped) {
       const diagnostics = [
+        ...service.getCompilerOptionsDiagnostics(),
         ...service.getSemanticDiagnostics(filename),
         ...service.getSyntacticDiagnostics(filename),
       ];


### PR DESCRIPTION
In version 3.0.0 projects that use `rootDir` in their `tsconfig.json` will get errors that the snippet compilation files are not in the source tree.