### PR TITLE
fix: import with file extensions

### DIFF
--- a/bin/compile-typescript-docs.ts
+++ b/bin/compile-typescript-docs.ts
@@ -3,7 +3,7 @@
 import ora from "ora";
 import chalk from "chalk";
 import * as yargs from "yargs";
-import * as TypeScriptDocsVerifier from "../index";
+import * as TypeScriptDocsVerifier from "../index.js";
 
 const cliOptions = yargs
   .option("input-files", {

--- a/index.ts
+++ b/index.ts
@@ -1,13 +1,13 @@
-import { PackageInfo } from "./src/PackageInfo";
+import { PackageInfo } from "./src/PackageInfo.js";
 import {
   SnippetCompiler,
   SnippetCompilationResult,
-} from "./src/SnippetCompiler";
+} from "./src/SnippetCompiler.js";
 
 export type {
   SnippetCompilationResult,
   CompilationError,
-} from "./src/SnippetCompiler";
+} from "./src/SnippetCompiler.js";
 
 const DEFAULT_FILES = ["README.md"];
 

--- a/index.ts
+++ b/index.ts
@@ -1,8 +1,8 @@
-import { PackageInfo } from "./src/PackageInfo.js";
+import { PackageInfo } from "./src/PackageInfo.ts";
 import {
   SnippetCompiler,
   SnippetCompilationResult,
-} from "./src/SnippetCompiler.js";
+} from "./src/SnippetCompiler.ts";
 
 export type {
   SnippetCompilationResult,

--- a/src/CodeBlockExtractor.ts
+++ b/src/CodeBlockExtractor.ts
@@ -1,4 +1,4 @@
-import { readFile } from "fs/promises";
+import { readFile } from "node:fs/promises";
 
 const TYPESCRIPT_CODE_PATTERN =
   /(?<!(?:<!--\s*ts-docs-verifier:ignore\s*-->[\r?\n]*))(?:```(?:(?:typescript)|(tsx?))\r?\n)((?:\r?\n|.)*?)(?:(?=```))/gi;

--- a/src/CodeCompiler.ts
+++ b/src/CodeCompiler.ts
@@ -1,5 +1,5 @@
 import ts from "typescript";
-import path from "path";
+import path from "node:path";
 
 const createServiceHost = (
   options: ts.CompilerOptions,

--- a/src/LocalImportSubstituter.ts
+++ b/src/LocalImportSubstituter.ts
@@ -1,10 +1,10 @@
-import * as path from "path";
+import * as path from "node:path";
 import {
   ConditionalExports,
   PackageDefinition,
   PackageExports,
   SubpathExports,
-} from "./PackageInfo.js";
+} from "./PackageInfo.ts";
 
 class ExportResolver {
   private readonly packageName: string;

--- a/src/LocalImportSubstituter.ts
+++ b/src/LocalImportSubstituter.ts
@@ -4,7 +4,7 @@ import {
   PackageDefinition,
   PackageExports,
   SubpathExports,
-} from "./PackageInfo";
+} from "./PackageInfo.js";
 
 class ExportResolver {
   private readonly packageName: string;

--- a/src/PackageInfo.ts
+++ b/src/PackageInfo.ts
@@ -1,5 +1,5 @@
-import * as path from "path";
-import { readFile } from "fs/promises";
+import * as path from "node:path";
+import { readFile } from "node:fs/promises";
 
 type ConditionalExportKeys =
   | "node-addons"

--- a/src/SnippetCompiler.ts
+++ b/src/SnippetCompiler.ts
@@ -1,9 +1,9 @@
 import fs from "fs";
 import ts from "typescript";
-import { PackageDefinition } from "./PackageInfo";
-import { CodeBlockExtractor } from "./CodeBlockExtractor";
-import { LocalImportSubstituter } from "./LocalImportSubstituter";
-import { compile } from "./CodeCompiler";
+import { PackageDefinition } from "./PackageInfo.js";
+import { CodeBlockExtractor } from "./CodeBlockExtractor.js";
+import { LocalImportSubstituter } from "./LocalImportSubstituter.js";
+import { compile } from "./CodeCompiler.js";
 
 type CodeBlock = {
   readonly file: string;

--- a/src/SnippetCompiler.ts
+++ b/src/SnippetCompiler.ts
@@ -1,9 +1,9 @@
-import fs from "fs";
+import fs from "node:fs";
 import ts from "typescript";
-import { PackageDefinition } from "./PackageInfo.js";
-import { CodeBlockExtractor } from "./CodeBlockExtractor.js";
-import { LocalImportSubstituter } from "./LocalImportSubstituter.js";
-import { compile } from "./CodeCompiler.js";
+import { PackageDefinition } from "./PackageInfo.ts";
+import { CodeBlockExtractor } from "./CodeBlockExtractor.ts";
+import { LocalImportSubstituter } from "./LocalImportSubstituter.ts";
+import { compile } from "./CodeCompiler.ts";
 
 type CodeBlock = {
   readonly file: string;

--- a/test/LocalImportSubstituterSpec.ts
+++ b/test/LocalImportSubstituterSpec.ts
@@ -1,5 +1,5 @@
 import { describe, it, type TestContext } from "node:test";
-import { LocalImportSubstituter } from "../src/LocalImportSubstituter";
+import { LocalImportSubstituter } from "../src/LocalImportSubstituter.ts";
 
 const defaultPackageInfo = {
   name: "my-package",

--- a/test/TypeScriptDocsVerifierSpec.ts
+++ b/test/TypeScriptDocsVerifierSpec.ts
@@ -4,8 +4,8 @@ import * as path from "node:path";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import { Gen, init } from "verify-it";
-import * as TypeScriptDocsVerifier from "../index";
-import { PackageDefinition } from "../src/PackageInfo";
+import * as TypeScriptDocsVerifier from "../index.ts";
+import { PackageDefinition } from "../src/PackageInfo.ts";
 
 const verify = init({ it, describe });
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -20,7 +20,8 @@
     "noImplicitReturns": true,
     "moduleResolution": "node",
     "typeRoots": ["node_modules/@types"],
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "rewriteRelativeImportExtensions": true
   },
   "files": ["index.ts", "bin/compile-typescript-docs.ts"]
 }


### PR DESCRIPTION
Recent versions of TypeScript don't implicitly add `.js` onto file imports so it's necssary to specify them.

Fixes `tsc` errors like the below when types from this module are referenced using `typescript@6`+

```
src/document-check.js:77:81 - error TS7006: Parameter 'code' implicitly has an 'any' type.

77                   const diagnosticCodes = result.error?.diagnosticCodes?.filter(code => !TS_ERRORS_TO_SUPPRESS.includes(code))
```